### PR TITLE
Landingzone related changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.6
-RUN apt-get update && apt-get install -y --no-install-recommends default-mysql-client=1.0.5 \
+RUN apt-get update && apt-get install -y --no-install-recommends default-mysql-client=1.0.5 dos2unix=7.4.0-1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /srv
 COPY . .
 RUN pip install -r ./requirements.txt
+RUN dos2unix app_docker.sh
 RUN ["chmod", "+x", "./app_docker.sh"]
 EXPOSE 3000
 CMD ["/bin/bash", "./app_docker.sh"]

--- a/tb_houston_service/GCP_DAC_Deployment.py
+++ b/tb_houston_service/GCP_DAC_Deployment.py
@@ -14,8 +14,8 @@ logger = logging.getLogger('tb_houston_service.GCP_DAC_Deployment')
 
 class GCP_DAC_Deployment:
     def __init__(self, deployment_type):
-        self.create_url = f"{os.environ['GCP_DAC_URL']}/api/{deployment_type}_async/"
-        self.create_result_url = f"http://{os.environ['GCP_DAC_URL']}/api/{deployment_type}_async/result/create/"
+        self.create_url = f"{os.environ['GCP_DAC_URL']}/dac/{deployment_type}_async/"
+        self.create_result_url = f"http://{os.environ['GCP_DAC_URL']}/dac/{deployment_type}_async/result/create/"
         self.headers = {"Content-Type": "application/json"}
 
     # Send the payload to the DAC

--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -16,9 +16,9 @@ from tb_houston_service.extendedSchemas import ExtendedApplicationForDACSchema
 
 logger = logging.getLogger("tb_houston_service.application_deployment")
 
-deployment_create_url = f"http://{os.environ['GCP_DAC_URL']}/api/application_async/"
+deployment_create_url = f"http://{os.environ['GCP_DAC_URL']}/dac/application_async/"
 deployment_create_result_url = (
-    f"http://{os.environ['GCP_DAC_URL']}/api/application_async/result/create/"
+    f"http://{os.environ['GCP_DAC_URL']}/dac/application_async/result/create/"
 )
 headers = {"Content-Type": "application/json"}
 

--- a/tb_houston_service/gcp_dac_folder_deployment.py
+++ b/tb_houston_service/gcp_dac_folder_deployment.py
@@ -14,10 +14,10 @@ from config import app
 
 gcp_dac_url = f"http://{os.environ['GCP_DAC_URL']}"
 headers = {"Content-Type": "application/json"}
-folder_url = f"{gcp_dac_url}/api/folder_async"
-metadata_url = f"{gcp_dac_url}/api/metadata"
-create_folder_result_url = f"{gcp_dac_url}/api/folder_async/result/create/"
-delete_folder_result_url = f"{gcp_dac_url}/api/folder_async/result/delete/"
+folder_url = f"{gcp_dac_url}/dac/folder_async"
+metadata_url = f"{gcp_dac_url}/dac/metadata"
+create_folder_result_url = f"{gcp_dac_url}/dac/folder_async/result/create/"
+delete_folder_result_url = f"{gcp_dac_url}/dac/folder_async/result/delete/"
 
 folderid_regex = re.compile(r"folders/(?P<folder>\w+)")
 

--- a/tb_houston_service/solution_deployment.py
+++ b/tb_houston_service/solution_deployment.py
@@ -27,9 +27,9 @@ from tb_houston_service import solutionresourcejson
 
 logger = logging.getLogger("tb_houston_service.solution_deployment")
 
-deployment_create_url = f"http://{os.environ['GCP_DAC_URL']}/api/solution_async/"
+deployment_create_url = f"http://{os.environ['GCP_DAC_URL']}/dac/solution_async/"
 deployment_create_result_url = (
-    f"http://{os.environ['GCP_DAC_URL']}/api/solution_async/result/create/"
+    f"http://{os.environ['GCP_DAC_URL']}/dac/solution_async/result/create/"
 )
 headers = {"Content-Type": "application/json"}
 


### PR DESCRIPTION
This PR contains changes to ensure the houston service works in the Kubernetes cluster within  the landing zone. 
* change prefix of api calls when calling DAC from /api to /dac
* add line ending check to shell script within Dockerfile.