### PR TITLE
#388 #389 Bugfix

### DIFF
--- a/tb_houston_service/activatorByURL.py
+++ b/tb_houston_service/activatorByURL.py
@@ -75,7 +75,7 @@ def get_file_from_repo(url):
     # Create temporary dir
     t = tempfile.mkdtemp()
     # Clone into temporary dir
-    repo = git.Repo.clone_from(url, t, branch='master', depth=1)
+    repo = git.Repo.clone_from(url, t, depth=1)
     tag = repo.tags.pop()
     act_metadata_yaml_file = open(os.path.join(t, ".tb/activator_metadata.yml"))
     act_metadata_yml_dict = yaml.load(act_metadata_yaml_file, Loader=yaml.FullLoader)
@@ -137,7 +137,7 @@ def create_activator_metadata_variables(dbs, activator_metadata_id, variables,is
 
     schema = ActivatorMetadataVariableSchema()
     
-    for variable in variables:
+    for variable in (variables or ()):
         variableDetails = {}
         variableDetails["activatorMetadataId"] = activator_metadata_id
         variableDetails["name"] = variable["name"]


### PR DESCRIPTION
- activator onboarding fails with default branch different than master
- activator onboarding fails without metadata variables

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Read, understand and follow the **[contribution guidelines](https://www.tranquilitybase.io/contribution-guidelines/)**
- [x] Tested UI/API integration with current master:
  - [x] Login
  - [x] "Create New Solution"
  - [x] "Create New Application"
  - [x] "Create New WAN VPN"
  - [x] Dev user is able to request access to a "Locked" Activator
  - [x] Admin user is able to "Grant Access", "Lock", "Deprecate" and "Undeprecate" an Activator


## PR Type
What kind of change does this PR introduce?

Please check the one that applies to this PR.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] TranquilityBase application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: 
 - closes #388 
 - closes #389


## What is the new behavior?
Onboarding new activator

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing stack below.


## Other information
