### PR TITLE
fast fail sandbox deployment if created by or cloud identity group not specified

### DIFF
--- a/tb_houston_service/solution_deployment.py
+++ b/tb_houston_service/solution_deployment.py
@@ -429,11 +429,11 @@ def send_sandbox_deployment_to_the_dac(sol_deployment, solution):
     logger.debug(
         "send_sandbox_deployment_to_the_dac::sandbox_deployment: %s", sandbox_data_json
     )
-    # check sandbox params - fail if these aren't sent
-    logger.debug("createdBy {}".format(sandbox_data["createdBy"]))
-    logger.debug("teamcloudIdentityGroup {}".format(sandbox_data["teamcloudIdentityGroup"]))
-    if sandbox_data["createdBy"] is None or sandbox_data["teamcloudIdentityGroup"] is None:
-        # FAILURE
+    # check sandbox params - fail and do not deploy if these aren't sent
+    created_by = sandbox_data["createdBy"]
+    identity_group = sandbox_data["teamcloudIdentityGroup"]
+    if created_by is None or identity_group is None:
+        logger.debug("Deployment not sent to DAC")
         deployment_json = {
             "id": oid,
             "taskId": "",
@@ -441,14 +441,14 @@ def send_sandbox_deployment_to_the_dac(sol_deployment, solution):
             "deploymentState": DeploymentStatus.FAILURE,
             "statusId": 200,
             "statusCode": "200",
-            "statusMessage": "sandbox deployment failed (not started) due to missing parameters created by or team cloud identity group",
+            "statusMessage": "sandbox deployment failed (not started) due to missing parameters created by: {} "
+                             "or team cloud identity group: {}".format(created_by, identity_group),
             "deploymentFolderId": sol_deployment.deploymentFolderId,
         }
 
         logger.debug(pformat(deployment_json))
         deployment_update(oid, deployment_json)
         return deployment_json
-
 
     resp_json = None
     try:

--- a/tb_houston_service/solution_extension.py
+++ b/tb_houston_service/solution_extension.py
@@ -100,7 +100,7 @@ def expand_solution_for_dac(sol, dbsession):
     if logged_in_user:
         sol.createdBy = f"{logged_in_user.firstName} {logged_in_user.lastName}"
     else:
-        sol.createdBy = "USERNOTFOUND"
+        sol.createdBy = None
     return sol
 
 def create_solution_environments(solutionId, list_of_env_ids, dbsession):


### PR DESCRIPTION
if created by or cloud identity group not specified then fast fail the sandbox deployment without calling DAC