### PR TITLE
#431 Send variables when activator is being deployed

### DIFF
--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -276,6 +276,8 @@ def deploy_application(app_deployment, dbsession):
         gitSnapshot = json.loads(act.gitSnapshotJson)
         if gitSnapshot and "git_clone_url" in gitSnapshot.keys():
             app_deployment.activatorGitUrl = gitSnapshot["git_clone_url"]
+        else:
+            raise Exception("Error, could not retrieve git_clone_url from gitSnapshot Json")
 
         app_deployment.optionalVariables = optional_pairs
         app_deployment.mandatoryVariables = mandatory_pairs
@@ -299,6 +301,7 @@ def deploy_application(app_deployment, dbsession):
             environment.sharedVPCProjectId = ""
         app_deployment.deploymentEnvironment = environment
 
+        print(str("== send_application_deployment_to_the_dac =="), flush=True)
         return send_application_deployment_to_the_dac(app_deployment, dbsession = dbsession)
     else:
         logger.error("deploy_application::activator not found, %s!", app.activatorId)

--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -255,10 +255,15 @@ def deploy_application(app_deployment, dbsession):
     optional_pairs = {}
     mandatory_pairs = {}
     for mvar in actMetadataVariable:
+        print(str("adding pair "), flush=True)
         key = mvar.name
+        print(str("key " + key), flush=True)
+
         if mvar.defaultValue is None:
+            print(str("value " + str(mvar.value)), flush=True)
             val = mvar.value
         else:
+            print(str("defaultValue " + str(mvar.defaultValue)), flush=True)
             val = mvar.defaultValue
 
         key_pair = {"key": key}

--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -247,10 +247,16 @@ def deploy_application(app_deployment, dbsession):
         app_deployment.workspaceProjectId = app_deployment.workspaceProjectId
         app_deployment.deploymentProjectId = app_deployment.deploymentProjectId
         app_deployment.mandatoryVariables = []
-        app_deployment.optionalVariables = []
+
+        if actMetadata:
+            app_deployment.optionalVariables = actMetadata
+        else:
+            app_deployment.optionalVariables = []
+
         app_deployment.id = app.id
         app_deployment.name = app.name
         app_deployment.description = app.description
+        # app_deployment.actMetadata = actMetadata
 
         environment, lzlanvpc = dbsession.query(LZEnvironment, LZLanVpc).filter(
             LZLanVpcEnvironment.lzlanvpcId == LZLanVpc.id, 

--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -259,13 +259,17 @@ def deploy_application(app_deployment, dbsession):
         if mvar.defaultValue is None:
             val = mvar.value
         else:
-            val = mvar.value
-        pair = {key: val}
+            val = mvar.defaultValue
+
+        key_pair = {"key": key}
+        val_pair = {"value": val}
 
         if mvar.isOptional:
-            optional_pairs.update(pair)
+            optional_pairs.update(key_pair)
+            optional_pairs.update(val_pair)
         else:
-            mandatory_pairs.update(pair)
+            mandatory_pairs.update(key_pair)
+            mandatory_pairs.update(val_pair)
 
     print(str("== optional_pairs =="), flush=True)
     print(str(optional_pairs), flush=True)

--- a/tb_houston_service/application_deployment.py
+++ b/tb_houston_service/application_deployment.py
@@ -252,8 +252,8 @@ def deploy_application(app_deployment, dbsession):
     for mvar in actMetadataVariable:
         print(str(mvar.__dict__), flush=True)
 
-    optional_pairs = {}
-    mandatory_pairs = {}
+    optional_pairs = list()
+    mandatory_pairs = list()
     for mvar in actMetadataVariable:
         print(str("adding pair "), flush=True)
         key = mvar.name
@@ -266,15 +266,15 @@ def deploy_application(app_deployment, dbsession):
             print(str("defaultValue " + str(mvar.defaultValue)), flush=True)
             val = mvar.defaultValue
 
-        key_pair = {"key": key}
-        val_pair = {"value": val}
+        print(str("val " + val), flush=True)
+
+        key_val_pair = {"key": key,
+                        "value": val}
 
         if mvar.isOptional:
-            optional_pairs.update(key_pair)
-            optional_pairs.update(val_pair)
+            optional_pairs.append(key_val_pair)
         else:
-            mandatory_pairs.update(key_pair)
-            mandatory_pairs.update(val_pair)
+            mandatory_pairs.append(key_val_pair)
 
     print(str("== optional_pairs =="), flush=True)
     print(str(optional_pairs), flush=True)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Read, understand and follow the **[contribution guidelines](https://www.tranquilitybase.io/contribution-guidelines/)**
- [ ] Tested UI/API integration with current master:
  - [ ] Login
  - [ ] "Create New Solution"
  - [ ] "Create New Application"
  - [ ] "Create New WAN VPN"
  - [ ] Dev user is able to request access to a "Locked" Activator
  - [ ] Admin user is able to "Grant Access", "Lock", "Deprecate" and "Undeprecate" an Activator


## PR Type
What kind of change does this PR introduce?

Please check the one that applies to this PR.

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] TranquilityBase application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing stack below.


## Other information
